### PR TITLE
HC-147: job name override

### DIFF
--- a/mozart/services/api_v01.py
+++ b/mozart/services/api_v01.py
@@ -284,6 +284,8 @@ class SubmitJob(Resource):
                         help='Job priority in the range of 0 to 9')
     parser.add_argument('tags', required=False, type=str,
                         help='JSON list of tags, e.g. ["dumby", "test_job"]')
+    parser.add_argument('name', required=False,
+                        type=str, help='base job name override; defaults to job type')
     parser.add_argument('payload_hash', required=False,
                         type=str, help='user-generated payload hash')
     parser.add_argument('enable_dedup', required=False,
@@ -315,6 +317,8 @@ class SubmitJob(Resource):
             priority = int(request.form.get(
                 'priority', request.args.get('priority', 0)))
             tags = request.form.get('tags', request.args.get('tags', None))
+            job_name = request.form.get(
+                'name', request.args.get('name', None))
             payload_hash = request.form.get(
                 'payload_hash', request.args.get('payload_hash', None))
             enable_dedup = str(request.form.get(
@@ -345,6 +349,7 @@ class SubmitJob(Resource):
             app.logger.warning(job_queue)
             job_json = hysds_commons.job_utils.resolve_hysds_job(job_type, job_queue, priority,
                                                                  tags, params,
+                                                                 job_name=job_name,
                                                                  payload_hash=payload_hash,
                                                                  enable_dedup=enable_dedup)
             ident = hysds_commons.job_utils.submit_hysds_job(job_json)

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -284,6 +284,8 @@ class SubmitJob(Resource):
                         help='Job priority in the range of 0 to 9')
     parser.add_argument('tags', required=False, type=str,
                         help='JSON list of tags, e.g. ["dumby", "test_job"]')
+    parser.add_argument('name', required=False,
+                        type=str, help='base job name override; defaults to job type')
     parser.add_argument('payload_hash', required=False,
                         type=str, help='user-generated payload hash')
     parser.add_argument('enable_dedup', required=False,
@@ -315,6 +317,8 @@ class SubmitJob(Resource):
             priority = int(request.form.get(
                 'priority', request.args.get('priority', 0)))
             tags = request.form.get('tags', request.args.get('tags', None))
+            job_name = request.form.get(
+                'name', request.args.get('name', None))
             payload_hash = request.form.get(
                 'payload_hash', request.args.get('payload_hash', None))
             enable_dedup = str(request.form.get(
@@ -345,6 +349,7 @@ class SubmitJob(Resource):
             app.logger.warning(job_queue)
             job_json = hysds_commons.job_utils.resolve_hysds_job(job_type, job_queue, priority,
                                                                  tags, params,
+                                                                 job_name=job_name,
                                                                  payload_hash=payload_hash,
                                                                  enable_dedup=enable_dedup)
             ident = hysds_commons.job_utils.submit_hysds_job(job_json)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mozart',
-    version='1.1.3',
+    version='1.1.4',
     long_description='HySDS job orchestration/worker web interface',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
This PR provides the capability to override the base job name of a job submitted via the Mozart REST API (https://hysds-core.atlassian.net/browse/HC-147).

Test results:
1. Submit 2 hello world jobs with job dedup disabled. First job doesn't specify `name` so the job type will be used for the base job name. Second job specifies `name` as `my-job-name-override`:
```
Python 3.7.6 (default, Jan  8 2020, 19:59:22) 
[GCC 7.3.0] :: Anaconda, Inc. on linux
Type “help”, “copyright”, “credits” or “license” for more information.
>>> import json, requests
>>> mozart_url = “https://<mozart_ip_address>/mozart/api/v0.1/job/submit”
>>> params = {
…     “queue”: “nisar-job_worker-small”,
…     “priority”: 5,
…     “tags”: ‘[“test”, “this”]’,
…     “type”: “job-hello_world:develop”,
…     “enable_dedup”: False,
…     “params”: “{}”,
… }
>>> r = requests.post(mozart_url, data=params, verify=False)
>>> r.raise_for_status()
>>> res = r.json()
>>> print(json.dumps(res, indent=2))
{
  “success”: true,
  “message”: “”,
  “result”: “901387b7-cc64-4000-b845-64d883d2de32”
}
>>> params[“name”] = “my-job-name-override”
>>> r = requests.post(mozart_url, data=params, verify=False)
>>> r.raise_for_status()
>>> res = r.json()
>>> print(json.dumps(res, indent=2))
{
  “success”: true,
  “message”: “”,
  “result”: “d983679c-a9ec-4f63-ba79-3ec615360818”
}
```

Verified job names using job status dump script and figaro:
```
$ ~/mozart/ops/nisar-pcm/conf/sds/files/test/dump_job_status.py https://127.0.0.1/mozart

╒══════════════════════════════════════════════════╕
│ uuid                                             │
│ —                                              │
│ job_id                                           │
│ —                                              │
│ status                                           │
│ —                                              │
│ error                                            │
│ —                                              │
│ traceback                                        │
╞══════════════════════════════════════════════════╡
│ 4446558f-fb08-4bfd-b4ab-2e272a030d3b             │
│ —                                              │
│ job-hello_world__develop-20200110T210249.233620Z │
│ —                                              │
│ job-completed                                    │
│ —                                              │
│                                                  │
│ —                                              │
├──────────────────────────────────────────────────┤
│ dc20fd77-c0a2-4002-a4bb-e6435a74e496             │
│ —                                              │
│ my-job-name-override-20200110T210249.412695Z     │
│ —                                              │
│ job-started                                      │
│ —                                              │
│                                                  │
│ —                                              │
╘══════════════════════════════════════════════════╛
```
![Screen Shot 2020-01-10 at 1 11 25 PM](https://user-images.githubusercontent.com/387300/72186723-bf96a800-33aa-11ea-9499-539a010f04ec.png)
