### PR TITLE
HC-175: install flask-restx v0.2.0 to address issues with werkzeug v1.0.0

### DIFF
--- a/configs/user_rules_job.mapping
+++ b/configs/user_rules_job.mapping
@@ -42,6 +42,18 @@
         "enabled": {
           "type": "boolean",
           "null_value": true
+        },
+        "resource": {
+          "index": "not_analyzed",
+          "type": "string"
+        },
+        "status": {
+          "index": "not_analyzed",
+          "type": "string"
+        },
+        "type": {
+          "index": "not_analyzed",
+          "type": "string"
         }
       }
     }

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,5 @@ setup(
                       'simplekml>=1.2.3', 'tornado>=4.0.2', 'pika>=0.9.14',
                       'pymongo>=2.7.2', 'boto>=2.38.0', 'python-dateutil',
                       'elasticsearch>=1.0.0,<2.0.0', 'pytz', 'numpy',
-                      # TODO: remove installation of master branch after new release of
-                      # flask-restx includes the fix referred to here:
-                      # https://github.com/python-restx/flask-restx/issues/85
-                      #'flask-restx>0.1.1',
-                      'flask-restx @ git+https://git@github.com/python-restx/flask-restx',
-                      'future>=0.17.1']
+                      'flask-restx>=0.2.0', 'future>=0.17.1']
 )


### PR DESCRIPTION
End-to-end test ran successfully on NISAR dev cluster