### PR TITLE
added 404 error in install_es_template

### DIFF
--- a/scripts/install_es_template.py
+++ b/scripts/install_es_template.py
@@ -23,7 +23,7 @@ def write_template(index, tmpl_file):
         tmpl = Template(f.read()).render(index=index)
 
     # https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.delete_template
-    mozart_es.es.indices.delete_template(name=index, ignore=400)
+    mozart_es.es.indices.delete_template(name=index, ignore=[400, 404])
 
     # https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.put_template
     mozart_es.es.indices.put_template(name=index, body=tmpl)


### PR DESCRIPTION
getting error when installing es templates if they dont exist
```
(remote-exec): [###.##.###.###] run: mozart/ops/mozart/scripts/install_es_template.sh mozart
 Still creating... [18m50s elapsed]
(remote-exec): [###.##.###.###] out: Traceback (most recent call last):
(remote-exec): [###.##.###.###] out:   File "/export/home/****/mozart/ops/mozart/scripts/install_es_template.py", line 41, in <module>
(remote-exec): [###.##.###.###] out:     write_template(index, tmpl_file)
(remote-exec): [###.##.###.###] out:   File "/export/home/****/mozart/ops/mozart/scripts/install_es_template.py", line 26, in write_template
(remote-exec): [###.##.###.###] out:     mozart_es.es.indices.delete_template(name=index, ignore=400)
(remote-exec): [###.##.###.###] out:   File "/export/home/****/mozart/lib/python3.7/site-packages/elasticsearch/client/utils.py", line 92, in _wrapped
(remote-exec): [###.##.###.###] out:     return func(*args, params=params, headers=headers, **kwargs)
(remote-exec): [###.##.###.###] out:   File "/export/home/****/mozart/lib/python3.7/site-packages/elasticsearch/client/indices.py", line 674, in delete_template
(remote-exec): [###.##.###.###] out:     "DELETE", _make_path("_template", name), params=params, headers=headers
(remote-exec): [###.##.###.###] out:   File "/export/home/****/mozart/lib/python3.7/site-packages/elasticsearch/transport.py", line 362, in perform_request
(remote-exec): [###.##.###.###] out:     timeout=timeout,
(remote-exec): [###.##.###.###] out:   File "/export/home/****/mozart/lib/python3.7/site-packages/elasticsearch/connection/http_urllib3.py", line 248, in perform_request
(remote-exec): [###.##.###.###] out:     self._raise_error(response.status, raw_data)
(remote-exec): [###.##.###.###] out:   File "/export/home/****/mozart/lib/python3.7/site-packages/elasticsearch/connection/base.py", line 244, in _raise_error(remote-exec): [###.##.###.###] out:     status_code, error_message, additional_info

(remote-exec): [###.##.###.###] out: elasticsearch.exceptions.NotFoundError: NotFoundError(404, 'index_template_missing_exception', 'index_template [containers] missing')
```