### PR TITLE
Hc 199

### DIFF
--- a/mozart/services/api_v01.py
+++ b/mozart/services/api_v01.py
@@ -1019,7 +1019,7 @@ class JobParams(Resource):
                 "term": {"job-specification.keyword": job_type}
             }
         }
-        documents = mozart_es.search(index=HYSDS_IOS_INDEX, query=query)
+        documents = mozart_es.search(index=HYSDS_IOS_INDEX, body=query)
 
         if documents['hits']['total']['value'] == 0:
             error_message = '%s not found' % job_type

--- a/mozart/services/api_v01.py
+++ b/mozart/services/api_v01.py
@@ -95,7 +95,7 @@ class GetJobTypes(Resource):
                 "match_all": {}
             }
         }
-        job_specs = mozart_es.query(JOB_SPECS_INDEX, query)
+        job_specs = mozart_es.query(index=JOB_SPECS_INDEX, body=query)
         ids = [job_spec['_id'] for job_spec in job_specs]
         return {
             'success': True,
@@ -130,7 +130,7 @@ class GetJobSpecType(Resource):
         if _id is None:
             return {'success': False, 'message': 'missing parameter: id'}, 400
 
-        job_spec = mozart_es.get_by_id(JOB_SPECS_INDEX, _id, safe=True)
+        job_spec = mozart_es.get_by_id(index=JOB_SPECS_INDEX, id=_id, ignore=404)
         if job_spec['found'] is False:
             app.logger.error('job_spec not found %s' % _id)
             return {
@@ -140,7 +140,7 @@ class GetJobSpecType(Resource):
 
         return {
             'success': True,
-            'message': "",
+            'message': "job spec for %s" % _id,
             'result': job_spec['_source']
         }
 
@@ -177,10 +177,10 @@ class AddJobSpecType(Resource):
         except (ValueError, KeyError, json.decoder.JSONDecodeError, Exception) as e:
             return {'success': False, 'message': e}, 400
 
-        mozart_es.index_document(JOB_SPECS_INDEX, obj, _id)
+        mozart_es.index_document(index=JOB_SPECS_INDEX, body=obj, id=_id)
         return {
             'success': True,
-            'message': "%s added to index %s" % (_id, HYSDS_IOS_INDEX),
+            'message': "job_spec %s added to index %s" % (_id, HYSDS_IOS_INDEX),
             'result': _id
         }
 
@@ -213,7 +213,7 @@ class RemoveJobSpecType(Resource):
                 'message': 'id parameter not included'
             }, 400
 
-        mozart_es.delete_by_id(JOB_SPECS_INDEX, _id)
+        mozart_es.delete_by_id(index=JOB_SPECS_INDEX, id=_id)
         app.logger.info('Deleted job_spec %s from index: %s' % (_id, JOB_SPECS_INDEX))
         return {
             'success': True,
@@ -395,7 +395,7 @@ class GetJobStatus(Resource):
         if _id is None:
             return {'success': False, 'message': 'id not supplied'}, 400
 
-        job_status = mozart_es.get_by_id(JOB_STATUS_INDEX, _id, safe=True)
+        job_status = mozart_es.get_by_id(index=JOB_STATUS_INDEX, id=_id, ignore=404)
         if job_status['found'] is False:
             return {
                 'success': False,
@@ -435,16 +435,7 @@ class GetJobs(Resource):
     @api.marshal_with(resp_model)
     def get(self):
         """Paginated list submitted jobs"""
-        query = {
-            "_source": {
-                "exclude": ["*"]
-            },
-            "query": {
-                "match_all": {}
-            }
-        }
-
-        jobs = mozart_es.query(JOB_STATUS_INDEX, query)
+        jobs = mozart_es.query(index=JOB_STATUS_INDEX, _source=False)
         return {
             'success': True,
             'message': "",
@@ -478,7 +469,7 @@ class GetJobInfo(Resource):
         if _id is None:
             return {'success': False, 'message': 'id must be supplied'}, 400
 
-        info = mozart_es.get_by_id(JOB_STATUS_INDEX, _id, safe=True)
+        info = mozart_es.get_by_id(index=JOB_STATUS_INDEX, id=_id, ignore=404)
         if info['found'] is False:
             return {
                 'success': False,
@@ -511,12 +502,7 @@ class GetContainerTypes(Resource):
     @api.marshal_with(resp_model_job_types)
     def get(self):
         """Get a list of containers managed by Mozart"""
-        query = {
-            "query": {
-                "match_all": {}
-            }
-        }
-        containers = mozart_es.query(CONTAINERS_INDEX, query)
+        containers = mozart_es.query(index=CONTAINERS_INDEX, _source=False)
         ids = [container['_id'] for container in containers]
 
         return {
@@ -568,7 +554,7 @@ class GetContainerAdd(Resource):
             'url': url,
             'version': version
         }
-        mozart_es.index_document(CONTAINERS_INDEX, container_obj, name)
+        mozart_es.index_document(index=CONTAINERS_INDEX, body=container_obj, id=name)
 
         return {
             'success': True,
@@ -603,11 +589,11 @@ class GetContainerRemove(Resource):
                 'message': 'id must be supplied'
             }, 400
 
-        mozart_es.delete_by_id(CONTAINERS_INDEX, _id)
+        mozart_es.delete_by_id(index=CONTAINERS_INDEX, id=_id)
         app.logger.info('Deleted container %s from index: %s' % (_id, CONTAINERS_INDEX))
         return {
             'success': True,
-            'message': ""
+            'message': "job_spec deleted: %s" % _id
         }
 
 
@@ -635,9 +621,12 @@ class GetContainerInfo(Resource):
         """Get information on container by ID"""
         _id = request.form.get('id', request.args.get('id', None))
 
-        container = mozart_es.get_by_id(CONTAINERS_INDEX, _id, safe=True)
+        container = mozart_es.get_by_id(index=CONTAINERS_INDEX, id=_id, ignore=404)
         if container['found'] is False:
-            return {'success': False, 'message': ""}, 404
+            return {
+                'success': False,
+                'message': ""
+            }, 404
 
         return {
             'success': True,
@@ -665,12 +654,7 @@ class GetHySDSIOTypes(Resource):
     @api.marshal_with(resp_model_job_types)
     def get(self):
         """List HySDS IO specifications"""
-        query = {
-            "query": {
-                "match_all": {}
-            }
-        }
-        hysds_ios = mozart_es.query(HYSDS_IOS_INDEX, query)
+        hysds_ios = mozart_es.query(index=HYSDS_IOS_INDEX, _source=False)
         ids = [hysds_io['_id'] for hysds_io in hysds_ios]
         return {
             'success': True,
@@ -705,7 +689,7 @@ class GetHySDSIOType(Resource):
         if _id is None:
             return {'success': False, 'message': 'missing parameter: id'}, 400
 
-        hysds_io = mozart_es.get_by_id(HYSDS_IOS_INDEX, _id, safe=True)
+        hysds_io = mozart_es.get_by_id(index=HYSDS_IOS_INDEX, id=_id, ignore=404)
         if hysds_io['found'] is False:
             return {'success': False, 'message': ""}, 404
 
@@ -747,9 +731,12 @@ class AddHySDSIOType(Resource):
             obj = json.loads(spec)
             _id = obj['id']
         except (ValueError, KeyError, json.decoder.JSONDecodeError, Exception) as e:
-            return {'success': False, 'message': e}, 400
+            return {
+                'success': False,
+                'message': e
+            }, 400
 
-        mozart_es.index_document(HYSDS_IOS_INDEX, obj, _id)
+        mozart_es.index_document(index=HYSDS_IOS_INDEX, body=obj, id=_id)
         return {
             'success': True,
             'message': "%s added to index %s" % (_id, HYSDS_IOS_INDEX),
@@ -782,12 +769,12 @@ class RemoveHySDSIOType(Resource):
         if _id is None:
             return {'success': False, 'message': 'id parameter not included'}, 400
 
-        mozart_es.delete_by_id(HYSDS_IOS_INDEX, _id)
+        mozart_es.delete_by_id(index=HYSDS_IOS_INDEX, id=_id)
         app.logger.info('deleted %s from index: %s' % (_id, HYSDS_IOS_INDEX))
 
         return {
             'success': True,
-            'message': ""
+            'message': "deleted hysds_io: %s" % _id
         }
 
 
@@ -914,7 +901,7 @@ class OnDemandJobs(Resource):
             }
         }
 
-        documents = mozart_es.query(HYSDS_IOS_INDEX, query)
+        documents = mozart_es.query(index=HYSDS_IOS_INDEX, body=query)
         documents = [{
             'hysds_io': row['_source']['id'],
             'job_spec': row['_source']['job-specification'],
@@ -961,8 +948,8 @@ class OnDemandJobs(Resource):
                 'message': 'missing field: [tags, job_type, hysds_io, queue, query]'
             }, 400
 
-        doc = mozart_es.get_by_id(HYSDS_IOS_INDEX, hysds_io, safe=True)
-        if doc is False:
+        doc = mozart_es.get_by_id(index=HYSDS_IOS_INDEX, id=hysds_io, ignore=404)
+        if doc['found'] is False:
             app.logger.error('failed to fetch %s, not found in hysds_ios' % hysds_io)
             return {
                 'success': False,
@@ -1020,8 +1007,6 @@ class JobParams(Resource):
     })
 
     parser = api.parser()
-    # parser.add_argument('dataset_info', required=True, type=str,
-    #                     location='form',  help="HySDS dataset info JSON")
 
     # @api.marshal_with(resp_model)
     def get(self):
@@ -1031,7 +1016,6 @@ class JobParams(Resource):
 
         query = {
             "query": {
-                # "term": {"_id": job_type}
                 "term": {"job-specification.keyword": job_type}
             }
         }
@@ -1039,7 +1023,10 @@ class JobParams(Resource):
 
         if documents['hits']['total']['value'] == 0:
             error_message = '%s not found' % job_type
-            return {'success': False, 'message': error_message}, 404
+            return {
+                'success': False,
+                'message': error_message
+            }, 404
 
         job_type = documents['hits']['hits'][0]
         job_params = job_type['_source']['params']
@@ -1054,8 +1041,7 @@ class JobParams(Resource):
 
 
 @user_rule_ns.route('', endpoint='user-rules')
-@api.doc(responses={200: "Success",
-                    500: "Execution failed"},
+@api.doc(responses={200: "Success", 500: "Execution failed"},
          description="Retrieve on job params for specific jobs")
 class UserRules(Resource):
     """User Rules API"""
@@ -1066,21 +1052,20 @@ class UserRules(Resource):
         user_rules_index = app.config['USER_RULES_INDEX']
 
         if _id:
-            rule = mozart_es.get_by_id(user_rules_index, _id, safe=True)
-            if rule['found'] is True:
+            rule = mozart_es.get_by_id(index=user_rules_index, id=_id, ignore=404)
+            if rule['found'] is False:
+                return {
+                    'success': False,
+                    'message': rule['message']
+                }, 404
+            else:
                 rule = {**rule, **rule['_source']}
                 return {
                     'success': True,
                     'rule': rule
                 }
-            else:
-                return {
-                    'success': False,
-                    'message': rule['message']
-                }, 500
 
-        query = {"query": {"match_all": {}}}
-        user_rules = mozart_es.query(user_rules_index, query)
+        user_rules = mozart_es.query(index=user_rules_index)
 
         parsed_user_rules = []
         for rule in user_rules:
@@ -1152,8 +1137,7 @@ class UserRules(Resource):
                 }
             }
         }
-        # existing_rules = es.count(index=user_rules_index, body=rule_exists_query)
-        existing_rules_count = mozart_es.get_count(user_rules_index, rule_exists_query)
+        existing_rules_count = mozart_es.get_count(index=user_rules_index, body=rule_exists_query)
         if existing_rules_count > 0:
             return {
                 'success': False,
@@ -1161,8 +1145,8 @@ class UserRules(Resource):
             }, 409
 
         # check if job_type (hysds_io) exists in elasticsearch
-        job_type = mozart_es.get_by_id(HYSDS_IOS_INDEX, hysds_io, safe=True)
-        if not job_type['found']:
+        job_type = mozart_es.get_by_id(index=HYSDS_IOS_INDEX, id=hysds_io, ignore=404)
+        if job_type['found'] is False:
             return {
                 'success': False,
                 'message': '%s not found' % hysds_io
@@ -1189,7 +1173,7 @@ class UserRules(Resource):
             "creation_time": now,
         }
 
-        result = mozart_es.index_document(user_rules_index, new_doc, refresh=True)
+        result = mozart_es.index_document(index=user_rules_index, body=new_doc, refresh=True)
         return {
             'success': True,
             'message': 'rule created',
@@ -1219,17 +1203,16 @@ class UserRules(Resource):
 
         # check if job_type (hysds_io) exists in elasticsearch (only if we're updating job_type)
         if hysds_io:
-            job_type = mozart_es.get_by_id(HYSDS_IOS_INDEX, hysds_io, safe=True)
-            if not job_type['found']:
+            job_type = mozart_es.get_by_id(index=HYSDS_IOS_INDEX, id=hysds_io, ignore=404)
+            if job_type['found'] is False:
                 return {
                     'success': False,
                     'message': 'job_type not found: %s' % hysds_io
-                }, 400
+                }, 404
 
         app.logger.info('finding existing user rule: %s' % _id)
-        # es.get(index=user_rules_index, doc_type='_doc', id=_id)
-        existing_rule = mozart_es.get_by_id(user_rules_index, _id, safe=True)
-        if not existing_rule['found']:
+        existing_rule = mozart_es.get_by_id(index=user_rules_index, id=_id, ignore=404)
+        if existing_rule['found'] is False:
             app.logger.info('rule not found %s' % _id)
             return {
                 'result': False,
@@ -1273,7 +1256,13 @@ class UserRules(Resource):
         update_doc['modified_time'] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
 
         app.logger.info('editing document id %s in user_rule index' % _id)
-        result = mozart_es.update_document(user_rules_index, _id, update_doc, refresh=True)
+
+        doc = {
+            'doc_as_upsert': True,
+            'doc': update_doc
+        }
+
+        result = mozart_es.update_document(index=user_rules_index, id=_id, body=doc, refresh=True)
         app.logger.info(result)
         app.logger.info('document updated: %s' % _id)
         return {
@@ -1292,8 +1281,8 @@ class UserRules(Resource):
                 'message': 'id not included'
             }, 400
 
-        result = mozart_es.delete_by_id(user_rules_index, _id, safe=True)
-        if result['result'] == 'not_found':
+        result = mozart_es.delete_by_id(index=user_rules_index, id=_id, ignore=404)
+        if result['found'] is False:
             app.logger.error('failed to delete %s from user_rules index' % _id)
             return {
                 'success': False,
@@ -1331,7 +1320,7 @@ class UserTags(Resource):
                 'message': 'id, index and tag must be supplied'
             }, 400
 
-        dataset = mozart_es.get_by_id(_index, _id, safe=True)
+        dataset = mozart_es.get_by_id(index=_index, id=_id, ignore=404)
         if dataset['found'] is False:
             return {
                 'success': False,
@@ -1347,9 +1336,12 @@ class UserTags(Resource):
             app.logger.info('tags after adding: %s' % str(user_tags))
 
         update_doc = {
-            'user_tags': user_tags
+            'doc_as_upsert': True,
+            'doc': {
+                'user_tags': user_tags
+            }
         }
-        mozart_es.update_document(_index, _id, update_doc, refresh=True)
+        mozart_es.update_document(index=_index, id=_id, body=update_doc, refresh=True)
 
         return {
             'success': True,
@@ -1375,7 +1367,7 @@ class UserTags(Resource):
                 'message': 'id and index must be supplied'
             }, 400
 
-        dataset = mozart_es.get_by_id(_index, _id, safe=True)
+        dataset = mozart_es.get_by_id(index=_index, id=_id, ignore=404)
         if dataset['found'] is False:
             return {
                 'success': False,
@@ -1393,9 +1385,12 @@ class UserTags(Resource):
             app.logger.warning('tag not found: %s' % tag)
 
         update_doc = {
-            'user_tags': user_tags
+            'doc_as_upsert': True,
+            'doc': {
+                'user_tags': user_tags
+            }
         }
-        mozart_es.update_document(_index, _id, update_doc, refresh=True)
+        mozart_es.update_document(index=_index, id=_id, body=update_doc, refresh=True)
 
         return {
             'success': True,

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -996,9 +996,9 @@ class UserRules(Resource):
         existing_rules_count = mozart_es.get_count(index=user_rules_index, body=rule_exists_query)
         if existing_rules_count > 0:
             return {
-                       'success': False,
-                       'message': 'user rule already exists: %s' % rule_name
-                   }, 409
+                'success': False,
+                'message': 'user rule already exists: %s' % rule_name
+            }, 409
 
         # check if job_type (hysds_io) exists in elasticsearch
         job_type = mozart_es.get_by_id(index=HYSDS_IOS_INDEX, id=hysds_io, ignore=404)

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -874,7 +874,7 @@ class JobParams(Resource):
                 "term": {"job-specification.keyword": job_type}
             }
         }
-        documents = mozart_es.search(index=HYSDS_IOS_INDEX, query=query)
+        documents = mozart_es.search(index=HYSDS_IOS_INDEX, body=query)
 
         if documents['hits']['total']['value'] == 0:
             error_message = '%s not found' % job_type

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mozart',
-    version='2.0.1',
+    version='2.0.2',
     long_description='HySDS job orchestration/worker web interface',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
https://hysds-core.atlassian.net/browse/HC-199
- refactoring `hysds_common`'s `ElasticsearchUtility` to allow for more flexibility
- re-using hysds core's elasticsearch connection because it allows us to read/write to AWS elasticsearch (defined in `.sds/config` and `celeryconfig.py`)
- `lightweight-jobs` will use hysds-core's ES connection

https://github.com/hysds/hysds_commons/pull/26/files#diff-0177d5302571ecb822b51229be69453d

tested `on-demand` and `user_rules` processing in both tosca and figaro