### PR TITLE
HC-67: Updated job post and status to be access controlled

### DIFF
--- a/mozart/lib/job_utils.py
+++ b/mozart/lib/job_utils.py
@@ -27,7 +27,7 @@ def get_job_status(ident):
     return hysds_commons.request_utils.get_requests_json_response(full_url)["_source"]["status"]
 
 
-def get_job_list(page_size=100, offset=0, username=None):
+def get_job_list(page_size=100, offset=0, username=None, detailed=False):
     '''
     Get a listing of jobs
     @param page_size - page size for pagination of jobs
@@ -44,7 +44,7 @@ def get_job_list(page_size=100, offset=0, username=None):
     full_url = "{0}/{1}/_search".format(es_url, es_index)
     results = hysds_commons.request_utils.post_scrolled_json_responses(
         full_url, "{0}/_search".format(es_url), data=json.dumps(data))
-    if username is None:
+    if detailed is False:
         return ([result["_id"] for result in results])
     else:
         return ([[result["_id"], result["_source"]["status"], result["_source"]["type"],

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -316,6 +316,7 @@ class SubmitJob(Resource):
                 'queue', request.args.get('queue', None))
             priority = int(request.form.get(
                 'priority', request.args.get('priority', 0)))
+            username = request.form.get('username', request.args.get('username', 'ops'))
             tags = request.form.get('tags', request.args.get('tags', None))
             job_name = request.form.get(
                 'name', request.args.get('name', None))
@@ -351,7 +352,8 @@ class SubmitJob(Resource):
                                                                  tags, params,
                                                                  job_name=job_name,
                                                                  payload_hash=payload_hash,
-                                                                 enable_dedup=enable_dedup)
+                                                                 enable_dedup=enable_dedup,
+                                                                 username=username)
             ident = hysds_commons.job_utils.submit_hysds_job(job_json)
         except Exception as e:
             message = "Failed to submit job. {0}:{1}".format(type(e), str(e))
@@ -426,6 +428,8 @@ class GetJobs(Resource):
     parser = api.parser()
     parser.add_argument('page_size', required=False, type=str,
                         help="Job Listing Pagination Size")
+    parser.add_argument('username', required=False, type=str,
+                        help="Username")
     parser = api.parser()
     parser.add_argument('offset', required=False, type=str,
                         help="Job Listing Pagination Offset")
@@ -436,10 +440,11 @@ class GetJobs(Resource):
         Paginated list submitted jobs 
         '''
         try:
+            username = request.form.get('username', request.args.get('username'), None)
             page_size = request.form.get(
                 'page_size', request.args.get('page_size', 100))
             offset = request.form.get('offset', request.args.get('id', 0))
-            jobs = mozart.lib.job_utils.get_job_list(page_size, offset)
+            jobs = mozart.lib.job_utils.get_job_list(page_size, offset, username)
         except Exception as e:
             message = "Failed to get job listing(page: {2}, offset: {3}). {0}:{1}".format(
                 type(e), str(e), page_size, offset)

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -430,6 +430,8 @@ class GetJobs(Resource):
                         help="Job Listing Pagination Size")
     parser.add_argument('username', required=False, type=str,
                         help="Username")
+    parser.add_argument('detailed', required=False, type=bool,
+                        help="Detailed job list flag")
     parser = api.parser()
     parser.add_argument('offset', required=False, type=str,
                         help="Job Listing Pagination Offset")
@@ -441,10 +443,11 @@ class GetJobs(Resource):
         '''
         try:
             username = request.form.get('username', request.args.get('username'), None)
+            detailed = request.args.get('detailed', False)
             page_size = request.form.get(
                 'page_size', request.args.get('page_size', 100))
             offset = request.form.get('offset', request.args.get('id', 0))
-            jobs = mozart.lib.job_utils.get_job_list(page_size, offset, username)
+            jobs = mozart.lib.job_utils.get_job_list(page_size, offset, username, detailed)
         except Exception as e:
             message = "Failed to get job listing(page: {2}, offset: {3}). {0}:{1}".format(
                 type(e), str(e), page_size, offset)

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -443,7 +443,7 @@ class GetJobs(Resource):
         '''
         try:
             username = request.form.get('username', request.args.get('username'), None)
-            detailed = request.args.get('detailed', False)
+            detailed = json.loads(request.form.get('detailed', request.args.get('detailed', False)).lower())
             page_size = request.form.get(
                 'page_size', request.args.get('page_size', 100))
             offset = request.form.get('offset', request.args.get('id', 0))

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -430,7 +430,7 @@ class GetJobs(Resource):
                         help="Job Listing Pagination Size")
     parser.add_argument('username', required=False, type=str,
                         help="Username")
-    parser.add_argument('detailed', required=False, type=bool,
+    parser.add_argument('detailed', required=False, type=str,
                         help="Detailed job list flag")
     parser = api.parser()
     parser.add_argument('offset', required=False, type=str,
@@ -443,7 +443,7 @@ class GetJobs(Resource):
         '''
         try:
             username = request.form.get('username', request.args.get('username'), None)
-            detailed = json.loads(request.form.get('detailed', request.args.get('detailed', False)).lower())
+            detailed = json.loads(request.form.get('detailed', request.args.get('detailed', 'False')).lower())
             page_size = request.form.get(
                 'page_size', request.args.get('page_size', 100))
             offset = request.form.get('offset', request.args.get('id', 0))


### PR DESCRIPTION
https://hysds-core.atlassian.net/browse/HC-67
Added access control to Mozart API for /job/submit and /job/list. This update is for v3.0.
_Updated behavior_:
**/job/submit** - username will now be added to the job metadata. We had this only when jobs were submitted from Tosca but the API. Now we propagate username information to the job's metadata and they show up under the username facet on Figaro.

**/job/list** - 

- If username is not provided, return list of all job IDs.
- If username provided, filter to only jobs for that user. Returns job ID, job status, job type and job param values. I extended the amount of information returned here because having hundreds of Job Ids are not useful to users when they are looking for their job history. It's more informative when they can see what those jobs were.

Made this backwards compatible, so even if username is not provided the behavior will be same as before.
I've tested these updates on the MAAP cluster.