### PR TITLE
HC-247: Add User Access Control to Mozart API endpoints

### DIFF
--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -386,7 +386,7 @@ class Jobs(Resource):
     @api.marshal_with(resp_model)
     def get(self):
         """Paginated list submitted jobs"""
-        detailed = request.args.get('detailed', False)
+        detailed = json.loads(request.form.get('detailed', request.args.get('detailed', False)).lower())
         username = request.form.get('username', request.args.get('username'), None)
         if username is None:
             query = {"query": {"match_all": {}}, "fields": []}

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -381,12 +381,12 @@ class Jobs(Resource):
     parser.add_argument('page_size', required=False, type=str, help="Job Listing Pagination Size")
     parser.add_argument('offset', required=False, type=str, help="Job Listing Pagination Offset")
     parser.add_argument('username', required=False, type=str, help="Username")
-    parser.add_argument('detailed', required=False, type=bool, help="Detailed Job List")
+    parser.add_argument('detailed', required=False, type=str, help="Detailed Job List")
 
     @api.marshal_with(resp_model)
     def get(self):
         """Paginated list submitted jobs"""
-        detailed = json.loads(request.form.get('detailed', request.args.get('detailed', False)).lower())
+        detailed = json.loads(request.form.get('detailed', request.args.get('detailed', 'False')).lower())
         username = request.form.get('username', request.args.get('username'), None)
         if username is None:
             query = {"query": {"match_all": {}}, "fields": []}

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -274,7 +274,7 @@ class SubmitJob(Resource):
             job_queue = request.form.get('queue', request.args.get('queue', None))
 
             priority = int(request.form.get('priority', request.args.get('priority', 0)))
-
+            username = request.form.get('username', request.args.get('username', 'ops'))
             tags = request.form.get('tags', request.args.get('tags', None))
             job_name = request.form.get('name', request.args.get('name', None))
 
@@ -311,7 +311,8 @@ class SubmitJob(Resource):
             job_json = hysds_commons.job_utils.resolve_hysds_job(job_type, job_queue, priority, tags, params,
                                                                  job_name=job_name,
                                                                  payload_hash=payload_hash,
-                                                                 enable_dedup=enable_dedup)
+                                                                 enable_dedup=enable_dedup,
+                                                                 username=username)
             ident = hysds_commons.job_utils.submit_hysds_job(job_json)
         except Exception as e:
             message = "Failed to submit job. {0}:{1}".format(type(e), str(e))
@@ -379,15 +380,28 @@ class Jobs(Resource):
     parser = api.parser()
     parser.add_argument('page_size', required=False, type=str, help="Job Listing Pagination Size")
     parser.add_argument('offset', required=False, type=str, help="Job Listing Pagination Offset")
+    parser.add_argument('username', required=False, type=str, help="Username")
+    parser.add_argument('detailed', required=False, type=bool, help="Detailed Job List")
 
     @api.marshal_with(resp_model)
     def get(self):
         """Paginated list submitted jobs"""
-        jobs = mozart_es.query(index=JOB_STATUS_INDEX, _source=False)
+        detailed = request.args.get('detailed', False)
+        username = request.form.get('username', request.args.get('username'), None)
+        if username is None:
+            query = {"query": {"match_all": {}}, "fields": []}
+        else:
+            query = {"query": {"bool": {"must": [{"term": {"job.job.username": username}}]}}}
+        jobs = mozart_es.query(index=JOB_STATUS_INDEX, body=query, _source=False)
+        if detailed:
+            result = sorted([job["_id"] for job in jobs])
+        else:
+            result = sorted([[result["_id"], result["_source"]["status"], result["_source"]["type"],
+                              result["_source"]["job"]["params"]["job_specification"]["params"]] for result in jobs])
         return {
             'success': True,
             'message': "",
-            'result': sorted([job["_id"] for job in jobs])
+            'result': result
         }
 
 


### PR DESCRIPTION
Added access control to Mozart API for `/job/submit` and `/job/list`. This update is for `v4.0`.
Updated behavior:
`/job/submit` - `username` will now be added to the job metadata. We had this only when jobs were submitted from Tosca but the API. Now we propagate username information to the job's metadata and they show up under the username facet on Figaro.

`/job/list` -
If `username` is not provided, get all jobs information.
If `username` provided, filter to only jobs for that user. 

- Added a flag `detailed` for specifying the format of response.
If `detailed` is `True` then, returns job ID, job status, job type and job param values. I extended the amount of information returned here because having hundreds of Job Ids are not useful to users when they are looking for their job history. It's more informative when they can see what those jobs were.
If `detailed` is `False` then, it defaults to previous behavior of returning list of job IDs.
Made this backwards compatible, so even if detailed flag is not provided the behavior will be same as before.