### PR TITLE
HC-255: Easily enable/disable trigger rules through the API

### DIFF
--- a/mozart/services/api_v01.py
+++ b/mozart/services/api_v01.py
@@ -1063,7 +1063,7 @@ class UserRules(Resource):
                     'message': rule['message']
                 }, 404
             else:
-                rule = {**rule, **rule['_source']}
+                rule = {**rule}
                 return {
                     'success': True,
                     'rule': rule
@@ -1076,7 +1076,7 @@ class UserRules(Resource):
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
             user_rule = result.get("hits").get("hits")[0]
-            user_rule = {**user_rule, **user_rule["_source"]}
+            user_rule = {**user_rule}
             return {
                 "success": True,
                 "rule": user_rule

--- a/mozart/services/api_v01.py
+++ b/mozart/services/api_v01.py
@@ -1063,7 +1063,7 @@ class UserRules(Resource):
                     'message': rule['message']
                 }, 404
             else:
-                rule = {**rule}
+                rule = {**rule["_source"]}
                 return {
                     'success': True,
                     'rule': rule
@@ -1076,7 +1076,7 @@ class UserRules(Resource):
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
             user_rule = result.get("hits").get("hits")[0]
-            user_rule = {**user_rule}
+            user_rule = {**user_rule["_source"]}
             return {
                 "success": True,
                 "rule": user_rule

--- a/mozart/services/api_v01.py
+++ b/mozart/services/api_v01.py
@@ -1069,7 +1069,7 @@ class UserRules(Resource):
                     'rule': rule
                 }
         elif _rule_name:
-            result = mozart_es.search(index=user_rules_index, q="rule_name.keyword:{}".format(_rule_name), ignore=404)
+            result = mozart_es.search(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
             if result.get("hits", {}).get("total", {}).get("value", 0) == 0:
                 return {
                     "success": False,
@@ -1254,7 +1254,7 @@ class UserRules(Resource):
                     'message': 'user rule not found: %s' % _id
                 }, 404
         elif _rule_name:
-            result = mozart_es.search(index=user_rules_index, q="rule_name.keyword:{}".format(_rule_name), ignore=404)
+            result = mozart_es.search(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
             if result.get("hits", {}).get("total", {}).get("value", 0) == 0:
                 return {
                            'success': False,
@@ -1352,7 +1352,7 @@ class UserRules(Resource):
             query = {
                 "query": {
                     "match": {
-                        "rule_name.keyword": _rule_name
+                        "rule_name": _rule_name
                     }
                 }
             }

--- a/mozart/services/api_v01.py
+++ b/mozart/services/api_v01.py
@@ -1051,13 +1051,13 @@ class UserRules(Resource):
 
     def get(self):
         # TODO: add user role and permissions
-        _id = request.args.get('id')
-        _rule_name = request.args.get("rule_name")
+        _id = request.args.get("id", None)
+        _rule_name = request.args.get("rule_name", None)
         user_rules_index = app.config['USER_RULES_INDEX']
 
         if _id:
             rule = mozart_es.get_by_id(index=user_rules_index, id=_id, ignore=404)
-            if rule['found'] is False:
+            if rule.get("found", False) is False:
                 return {
                     'success': False,
                     'message': rule['message']
@@ -1069,12 +1069,13 @@ class UserRules(Resource):
                     'rule': rule
                 }
         elif _rule_name:
-            user_rule = mozart_es.search(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
-            if user_rule["found"] is False:
+            result = mozart_es.search(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
+            if result.get("hits", {}).get("total", {}).get("value", 0) == 0:
                 return {
                     "success": False,
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
+            user_rule = result.get("hits").get("hits")[0]
             user_rule = {**user_rule, **user_rule["_source"]}
             return {
                 "success": True,
@@ -1126,6 +1127,13 @@ class UserRules(Resource):
                 'success': False,
                 'message': 'Params not specified: %s' % ', '.join(missing_params),
                 'result': None,
+            }, 400
+
+        if len(rule_name) > 32:
+            return {
+                "success": False,
+                "message": "rule_name needs to be less than 32 characters",
+                "result": None,
             }, 400
 
         try:
@@ -1230,7 +1238,7 @@ class UserRules(Resource):
         # check if job_type (hysds_io) exists in elasticsearch (only if we're updating job_type)
         if hysds_io:
             job_type = mozart_es.get_by_id(index=HYSDS_IOS_INDEX, id=hysds_io, ignore=404)
-            if job_type['found'] is False:
+            if job_type.get("found", False) is False:
                 return {
                     'success': False,
                     'message': 'job_type not found: %s' % hysds_io
@@ -1239,21 +1247,21 @@ class UserRules(Resource):
         if _id:
             app.logger.info('finding existing user rule: %s' % _id)
             existing_rule = mozart_es.get_by_id(index=user_rules_index, id=_id, ignore=404)
-            if existing_rule['found'] is False:
+            if existing_rule.get("found", False) is False:
                 app.logger.info('rule not found %s' % _id)
                 return {
                     'result': False,
                     'message': 'user rule not found: %s' % _id
                 }, 404
         elif _rule_name:
-            existing_rule = mozart_es.search(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
-            if existing_rule['found'] is False:
+            result = mozart_es.search(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
+            if result.get("hits", {}).get("total", {}).get("value", 0) == 0:
                 return {
                            'success': False,
                            'message': 'rule %s not found' % _rule_name
                        }, 404
             else:
-                _id = existing_rule.get("_id")
+                _id = result.get("hits").get("hits")[0].get("_id")
 
         update_doc = {}
         if rule_name:
@@ -1288,7 +1296,14 @@ class UserRules(Resource):
         if queue:
             update_doc['queue'] = queue
         if enabled is not None:
-            update_doc['enabled'] = enabled
+            if isinstance(enabled, str):
+                if enabled.lower() == "false":
+                    value = False
+                else:
+                    value = True
+                update_doc["enabled"] = value
+            else:
+                update_doc["enabled"] = enabled
         if tags is not None:
             if type(tags) == str:
                 tags = [tags]
@@ -1328,7 +1343,14 @@ class UserRules(Resource):
             }
         elif "rule_name" in request.args:
             _rule_name = request.args.get("rule_name")
-            mozart_es.es.delete_by_query(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
+            query = {
+                "query": {
+                    "match": {
+                        "rule_name": _rule_name
+                    }
+                }
+            }
+            mozart_es.es.delete_by_query(index=user_rules_index, body=query, ignore=404)
             app.logger.info('user rule %s deleted' % _rule_name)
             return {
                 'success': True,

--- a/mozart/services/api_v01.py
+++ b/mozart/services/api_v01.py
@@ -1063,7 +1063,8 @@ class UserRules(Resource):
                     'message': rule['message']
                 }, 404
             else:
-                rule = rule["_source"]
+                rule = {**rule, **rule["_source"]}
+                rule.pop("_source", None)
                 return {
                     'success': True,
                     'rule': rule
@@ -1075,11 +1076,12 @@ class UserRules(Resource):
                     "success": False,
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
-            user_rule = result.get("hits").get("hits")[0]
-            user_rule = user_rule["_source"]
+            rule = result.get("hits").get("hits")[0]
+            rule = {**rule, **rule["_source"]}
+            rule.pop("_source", None)
             return {
                 "success": True,
-                "rule": user_rule
+                "rule": rule
             }
 
         user_rules = mozart_es.query(index=user_rules_index)

--- a/mozart/services/api_v01.py
+++ b/mozart/services/api_v01.py
@@ -1265,6 +1265,12 @@ class UserRules(Resource):
 
         update_doc = {}
         if rule_name:
+            if len(rule_name) > 32:
+                return {
+                           "success": False,
+                           "message": "rule_name needs to be less than 32 characters",
+                           "result": None,
+                       }, 400
             update_doc['rule_name'] = rule_name
         if hysds_io:
             update_doc['workflow'] = hysds_io

--- a/mozart/services/api_v01.py
+++ b/mozart/services/api_v01.py
@@ -1069,7 +1069,7 @@ class UserRules(Resource):
                     'rule': rule
                 }
         elif _rule_name:
-            result = mozart_es.search(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
+            result = mozart_es.search(index=user_rules_index, q="rule_name.keyword:{}".format(_rule_name), ignore=404)
             if result.get("hits", {}).get("total", {}).get("value", 0) == 0:
                 return {
                     "success": False,
@@ -1254,7 +1254,7 @@ class UserRules(Resource):
                     'message': 'user rule not found: %s' % _id
                 }, 404
         elif _rule_name:
-            result = mozart_es.search(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
+            result = mozart_es.search(index=user_rules_index, q="rule_name.keyword:{}".format(_rule_name), ignore=404)
             if result.get("hits", {}).get("total", {}).get("value", 0) == 0:
                 return {
                            'success': False,
@@ -1352,7 +1352,7 @@ class UserRules(Resource):
             query = {
                 "query": {
                     "match": {
-                        "rule_name": _rule_name
+                        "rule_name.keyword": _rule_name
                     }
                 }
             }

--- a/mozart/services/api_v01.py
+++ b/mozart/services/api_v01.py
@@ -1063,7 +1063,7 @@ class UserRules(Resource):
                     'message': rule['message']
                 }, 404
             else:
-                rule = {rule["_source"]}
+                rule = rule["_source"]
                 return {
                     'success': True,
                     'rule': rule
@@ -1076,7 +1076,7 @@ class UserRules(Resource):
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
             user_rule = result.get("hits").get("hits")[0]
-            user_rule = {user_rule["_source"]}
+            user_rule = user_rule["_source"]
             return {
                 "success": True,
                 "rule": user_rule

--- a/mozart/services/api_v01.py
+++ b/mozart/services/api_v01.py
@@ -1063,7 +1063,7 @@ class UserRules(Resource):
                     'message': rule['message']
                 }, 404
             else:
-                rule = {**rule["_source"]}
+                rule = {rule["_source"]}
                 return {
                     'success': True,
                     'rule': rule
@@ -1076,7 +1076,7 @@ class UserRules(Resource):
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
             user_rule = result.get("hits").get("hits")[0]
-            user_rule = {**user_rule["_source"]}
+            user_rule = {user_rule["_source"]}
             return {
                 "success": True,
                 "rule": user_rule
@@ -1211,15 +1211,12 @@ class UserRules(Resource):
 
     def put(self):  # TODO: add user role and permissions
         request_data = request.json or request.form
-        _id = None
-        _rule_name = None
-        if "id" in request_data:
-            _id = request_data.get('id')
-        elif "rule_name" in request_data:
-            _rule_name = request_data.get("rule_name")
-        else:
+        _id = request_data.get("id", None)
+        _rule_name = request_data.get("rule_name", None)
+
+        if not _id and not _rule_name:
             return {
-                "result": False,
+                "success": False,
                 "message": "Must specify id or rule_name in the request"
             }, 400
 
@@ -1335,11 +1332,15 @@ class UserRules(Resource):
     def delete(self):
         # TODO: need to add user rules and permissions
         user_rules_index = app.config['USER_RULES_INDEX']
-        _id = None
-        _rule_name = None
+        _id = request.args.get("id", None)
+        _rule_name = request.args.get("rule_name", None)
 
-        if "id" in request.args:
-            _id = request.args.get('id')
+        if not _id and not _rule_name:
+            return {"success": False,
+                    "message": "Must specify id or rule_name in the request"
+                    }, 400
+
+        if _id:
             mozart_es.delete_by_id(index=user_rules_index, id=_id, ignore=404)
             app.logger.info('user rule %s deleted' % _id)
             return {
@@ -1347,8 +1348,7 @@ class UserRules(Resource):
                 'message': 'user rule deleted',
                 'id': _id
             }
-        elif "rule_name" in request.args:
-            _rule_name = request.args.get("rule_name")
+        elif _rule_name:
             query = {
                 "query": {
                     "match": {
@@ -1363,8 +1363,6 @@ class UserRules(Resource):
                 'message': 'user rule deleted',
                 'rule_name': _rule_name
             }
-        else:
-            return {'result': False, 'message': 'id or rule_name not included'}, 400
 
 
 @user_tags_ns.route('', endpoint='user-tags')

--- a/mozart/services/api_v01.py
+++ b/mozart/services/api_v01.py
@@ -1052,6 +1052,7 @@ class UserRules(Resource):
     def get(self):
         # TODO: add user role and permissions
         _id = request.args.get('id')
+        _rule_name = request.args.get("rule_name")
         user_rules_index = app.config['USER_RULES_INDEX']
 
         if _id:
@@ -1067,6 +1068,18 @@ class UserRules(Resource):
                     'success': True,
                     'rule': rule
                 }
+        elif _rule_name:
+            user_rule = mozart_es.search(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
+            if user_rule["found"] is False:
+                return {
+                    "success": False,
+                    "message": "rule {} not found".format(_rule_name)
+                }, 404
+            user_rule = {**user_rule, **user_rule["_source"]}
+            return {
+                "success": True,
+                "rule": user_rule
+            }
 
         user_rules = mozart_es.query(index=user_rules_index)
 
@@ -1190,12 +1203,16 @@ class UserRules(Resource):
 
     def put(self):  # TODO: add user role and permissions
         request_data = request.json or request.form
-
-        _id = request_data.get('id')
-        if not _id:
+        _id = None
+        _rule_name = None
+        if "id" in request_data:
+            _id = request_data.get('id')
+        elif "rule_name" in request_data:
+            _rule_name = request_data.get("rule_name")
+        else:
             return {
-                'result': False,
-                'message': 'id not included'
+                "result": False,
+                "message": "Must specify id or rule_name in the request"
             }, 400
 
         user_rules_index = app.config['USER_RULES_INDEX']
@@ -1219,14 +1236,24 @@ class UserRules(Resource):
                     'message': 'job_type not found: %s' % hysds_io
                 }, 404
 
-        app.logger.info('finding existing user rule: %s' % _id)
-        existing_rule = mozart_es.get_by_id(index=user_rules_index, id=_id, ignore=404)
-        if existing_rule['found'] is False:
-            app.logger.info('rule not found %s' % _id)
-            return {
-                'result': False,
-                'message': 'user rule not found: %s' % _id
-            }, 404
+        if _id:
+            app.logger.info('finding existing user rule: %s' % _id)
+            existing_rule = mozart_es.get_by_id(index=user_rules_index, id=_id, ignore=404)
+            if existing_rule['found'] is False:
+                app.logger.info('rule not found %s' % _id)
+                return {
+                    'result': False,
+                    'message': 'user rule not found: %s' % _id
+                }, 404
+        elif _rule_name:
+            existing_rule = mozart_es.search(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
+            if existing_rule['found'] is False:
+                return {
+                           'success': False,
+                           'message': 'rule %s not found' % _rule_name
+                       }, 404
+            else:
+                _id = existing_rule.get("_id")
 
         update_doc = {}
         if rule_name:
@@ -1287,27 +1314,29 @@ class UserRules(Resource):
     def delete(self):
         # TODO: need to add user rules and permissions
         user_rules_index = app.config['USER_RULES_INDEX']
-        _id = request.args.get('id')
-        if not _id:
-            return {
-                'result': False,
-                'message': 'id not included'
-            }, 400
+        _id = None
+        _rule_name = None
 
-        result = mozart_es.delete_by_id(index=user_rules_index, id=_id, ignore=404)
-        if result['found'] is False:
-            app.logger.error('failed to delete %s from user_rules index' % _id)
+        if "id" in request.args:
+            _id = request.args.get('id')
+            mozart_es.delete_by_id(index=user_rules_index, id=_id, ignore=404)
+            app.logger.info('user rule %s deleted' % _id)
             return {
-                'success': False,
-                'message': 'user rule not found: %s' % _id
-            }, 404
-
-        app.logger.info('user rule deleted: %s' % _id)
-        return {
-            'success': True,
-            'message': 'user rule deleted',
-            'id': _id
-        }
+                'success': True,
+                'message': 'user rule deleted',
+                'id': _id
+            }
+        elif "rule_name" in request.args:
+            _rule_name = request.args.get("rule_name")
+            mozart_es.es.delete_by_query(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
+            app.logger.info('user rule %s deleted' % _rule_name)
+            return {
+                'success': True,
+                'message': 'user rule deleted',
+                'rule_name': _rule_name
+            }
+        else:
+            return {'result': False, 'message': 'id or rule_name not included'}, 400
 
 
 @user_tags_ns.route('', endpoint='user-tags')

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -924,7 +924,7 @@ class UserRules(Resource):
                     'rule': rule
                 }
         elif _rule_name:
-            result = mozart_es.search(index=user_rules_index, q="rule_name.keyword:{}".format(_rule_name), ignore=404)
+            result = mozart_es.search(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
             if result.get("hits", {}).get("total", {}).get("value", 0) == 0:
                 return {
                     "success": False,
@@ -1111,7 +1111,7 @@ class UserRules(Resource):
                 }, 404
         elif _rule_name:
             app.logger.info('finding existing user rule: %s' % _rule_name)
-            result = mozart_es.search(index=user_rules_index, q="rule_name.keyword:{}".format(_rule_name), ignore=404)
+            result = mozart_es.search(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
             if result.get("hits", {}).get("total", {}).get("value", 0) == 0:
                 return {
                            'success': False,
@@ -1209,7 +1209,7 @@ class UserRules(Resource):
             query = {
                 "query": {
                     "match": {
-                        "rule_name.keyword": _rule_name
+                        "rule_name": _rule_name
                     }
                 }
             }

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -1122,6 +1122,12 @@ class UserRules(Resource):
 
         update_doc = {}
         if rule_name:
+            if len(rule_name) > 32:
+                return {
+                           "success": False,
+                           "message": "rule_name needs to be less than 32 characters",
+                           "result": None,
+                       }, 400
             update_doc['rule_name'] = rule_name
         if hysds_io:
             update_doc['workflow'] = hysds_io

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -918,7 +918,7 @@ class UserRules(Resource):
                     'message': rule['message']
                 }, 404
             else:
-                rule = {rule["_source"]}
+                rule = rule["_source"]
                 return {
                     'success': True,
                     'rule': rule
@@ -931,7 +931,7 @@ class UserRules(Resource):
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
             user_rule = result.get("hits").get("hits")[0]
-            user_rule = {user_rule["_source"]}
+            user_rule = user_rule["_source"]
             return {
                 "success": True,
                 "rule": user_rule

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -918,7 +918,7 @@ class UserRules(Resource):
                     'message': rule['message']
                 }, 404
             else:
-                rule = {**rule, **rule['_source']}
+                rule = {**rule}
                 return {
                     'success': True,
                     'rule': rule
@@ -931,7 +931,7 @@ class UserRules(Resource):
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
             user_rule = result.get("hits").get("hits")[0]
-            user_rule = {**user_rule, **user_rule["_source"]}
+            user_rule = {**user_rule}
             return {
                 "success": True,
                 "rule": user_rule

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -918,7 +918,8 @@ class UserRules(Resource):
                     'message': rule['message']
                 }, 404
             else:
-                rule = rule["_source"]
+                rule = {**rule, **rule["_source"]}
+                rule.pop("_source", None)
                 return {
                     'success': True,
                     'rule': rule
@@ -930,11 +931,12 @@ class UserRules(Resource):
                     "success": False,
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
-            user_rule = result.get("hits").get("hits")[0]
-            user_rule = user_rule["_source"]
+            rule = result.get("hits").get("hits")[0]
+            rule = {**rule, **rule["_source"]}
+            rule.pop("_source", None)
             return {
                 "success": True,
-                "rule": user_rule
+                "rule": rule
             }
 
         user_rules = mozart_es.query(index=user_rules_index)

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -918,7 +918,7 @@ class UserRules(Resource):
                     'message': rule['message']
                 }, 404
             else:
-                rule = {**rule}
+                rule = {**rule["_source"]}
                 return {
                     'success': True,
                     'rule': rule
@@ -931,7 +931,7 @@ class UserRules(Resource):
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
             user_rule = result.get("hits").get("hits")[0]
-            user_rule = {**user_rule}
+            user_rule = {**user_rule["_source"]}
             return {
                 "success": True,
                 "rule": user_rule

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -924,7 +924,7 @@ class UserRules(Resource):
                     'rule': rule
                 }
         elif _rule_name:
-            result = mozart_es.search(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
+            result = mozart_es.search(index=user_rules_index, q="rule_name.keyword:{}".format(_rule_name), ignore=404)
             if result.get("hits", {}).get("total", {}).get("value", 0) == 0:
                 return {
                     "success": False,
@@ -1111,7 +1111,7 @@ class UserRules(Resource):
                 }, 404
         elif _rule_name:
             app.logger.info('finding existing user rule: %s' % _rule_name)
-            result = mozart_es.search(index=user_rules_index, q="rule_name:{}".format(_rule_name), ignore=404)
+            result = mozart_es.search(index=user_rules_index, q="rule_name.keyword:{}".format(_rule_name), ignore=404)
             if result.get("hits", {}).get("total", {}).get("value", 0) == 0:
                 return {
                            'success': False,
@@ -1209,7 +1209,7 @@ class UserRules(Resource):
             query = {
                 "query": {
                     "match": {
-                        "rule_name": _rule_name
+                        "rule_name.keyword": _rule_name
                     }
                 }
             }

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mozart',
-    version='2.0.4',
+    version='2.0.5',
     long_description='HySDS job orchestration/worker web interface',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
This PR updates the GET, PUT, POST, and DELETE operations for the user-rules, where we can now query by a trigger rule name as well. Also updated the POST and PUT operations to check for rule names longer than 32 characters.

See https://hysds-core.atlassian.net/browse/HC-255 for how this was tested on a local cluster. 