### PR TITLE
HC-314: Added flag paginate to specify pagination

### DIFF
--- a/mozart/lib/job_utils.py
+++ b/mozart/lib/job_utils.py
@@ -27,7 +27,7 @@ def get_job_status(ident):
     return hysds_commons.request_utils.get_requests_json_response(full_url)["_source"]["status"]
 
 
-def get_job_list(page_size=100, offset=0, username=None, detailed=False):
+def get_job_list(page_size=100, offset=0, username=None, detailed=False, paginate=False):
     '''
     Get a listing of jobs
     @param page_size - page size for pagination of jobs
@@ -39,11 +39,14 @@ def get_job_list(page_size=100, offset=0, username=None, detailed=False):
     else:
         data = {"query": {"bool": {"must": [{"term": {"job.job.username": username}}]}}}
 
+    data["from"] = offset
+    data["size"] = page_size
+
     es_url = app.config['ES_URL']
     es_index = "job_status-current"
     full_url = "{0}/{1}/_search".format(es_url, es_index)
     results = hysds_commons.request_utils.post_scrolled_json_responses(
-        full_url, "{0}/_search".format(es_url), data=json.dumps(data))
+        full_url, "{0}/_search".format(es_url), data=json.dumps(data), paginate=paginate)
     if detailed is False:
         return ([result["_id"] for result in results])
     else:

--- a/mozart/services/api_v02.py
+++ b/mozart/services/api_v02.py
@@ -428,13 +428,16 @@ class GetJobs(Resource):
     parser = api.parser()
     parser.add_argument('page_size', required=False, type=str,
                         help="Job Listing Pagination Size")
+    parser.add_argument('offset', required=False, type=str,
+                        help="Job Listing Pagination Offset")
     parser.add_argument('username', required=False, type=str,
                         help="Username")
     parser.add_argument('detailed', required=False, type=str,
                         help="Detailed job list flag")
-    parser = api.parser()
-    parser.add_argument('offset', required=False, type=str,
-                        help="Job Listing Pagination Offset")
+    parser.add_argument('paginate', required=False, type=str,
+                        help="Limiting result to input size and offset")
+
+
 
     @api.marshal_with(resp_model)
     def get(self):
@@ -444,10 +447,11 @@ class GetJobs(Resource):
         try:
             username = request.form.get('username', request.args.get('username'), None)
             detailed = json.loads(request.form.get('detailed', request.args.get('detailed', 'False')).lower())
+            paginate = json.loads(request.form.get('paginate', request.args.get('paginate', 'False')).lower())
             page_size = request.form.get(
                 'page_size', request.args.get('page_size', 100))
             offset = request.form.get('offset', request.args.get('id', 0))
-            jobs = mozart.lib.job_utils.get_job_list(page_size, offset, username, detailed)
+            jobs = mozart.lib.job_utils.get_job_list(page_size, offset, username, detailed, paginate)
         except Exception as e:
             message = "Failed to get job listing(page: {2}, offset: {3}). {0}:{1}".format(
                 type(e), str(e), page_size, offset)


### PR DESCRIPTION
Update the Mozart API endpoint `/job/list` to expose pagination. Introduced a new boolean parameter `paginate`. By default pagination is `False` to ensure backwards compatibility.
If `paginate` is set to `True` results should be limited by page size and offset. 
If `paginate` is `False` or is not specified, the function will scan, collect and return all records for the query.