### PR TITLE
HC-450 - address issue relating to SQLAlchemy 2.0.0 update

### DIFF
--- a/db_create.py
+++ b/db_create.py
@@ -5,5 +5,8 @@ from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-from mozart import db
-db.create_all()
+
+from mozart import app, db
+
+with app.app_context():
+    db.create_all()

--- a/setup.py
+++ b/setup.py
@@ -9,21 +9,21 @@ from setuptools import setup, find_packages
 
 setup(
     name='mozart',
-    version='2.0.16',
+    version='2.0.17',
     long_description='HySDS job orchestration/worker web interface',
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'Flask>=2.0.0',
+        'Flask>=2.2.0',
         'flask-restx>=0.5.1',
-        'Flask-SQLAlchemy>=2.5.1',
+        'Flask-SQLAlchemy>=3.0.0',
         'Flask-WTF>=0.15.1',
         'Flask-DebugToolbar>=0.11.0',
         'Flask-Login>=0.5.0',
         'gunicorn>=20.1.0',
         'gevent>=1.1.1',
-        'eventlet>=0.17.4',
+        'eventlet>=0.33.3',
         'requests>=2.7.0',
         'simpleldap>=0.8',
         'simplekml>=1.2.3',
@@ -37,6 +37,6 @@ setup(
         'future>=0.17.1',
         'pytz',
         'numpy',
-        "werkzeug==2.1.2",  # TODO: remove this pin after fix has been made https://stackoverflow.com/a/73105878
+        "werkzeug>=2.2.0",  # TODO: remove this pin after fix has been made https://stackoverflow.com/a/73105878
     ]
 )


### PR DESCRIPTION
change(s):
- packages that needed to be updated:
  - `Flask>=2.0.0` → `Flask>=2.2.0`
  - `Flask-SQLAlchemy>=2.5.1` → `Flask-SQLAlchemy>=3.0.0`
  - `werkzeug==2.1.2` → `werkzeug>=2.2.0` ([Flask needs werkzeug to be >=2.2.0](https://github.com/pallets/flask/blob/2.2.0/setup.py#L7))
- `db_create.py` is now using the `app` context when creating the database


found related closed GitHub issue from Flask-SQLAlchemy: https://github.com/pallets-eco/flask-sqlalchemy/issues/1158 . They say to update the version of Flask-SQLAlchemy as well.


after changes, was able to run `sds -d update mozart --force`
```bash
(mozart) hysdsops@ip-###-##-###-###:~/mozart/ops/mozart$ sds update mozart --force
Updating hysds_ui co:  44%|█████████████████████████████████████████████████████████████████████████▎                                                                                           | 20/45 [00:39<00:48,  1.93s/it]using default tosca configuration
using default figaro configuration
Updated verdi code/c: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 45/45 [01:50<00:00,  2.46s/it]
```
