### PR TITLE
Fix handling of request.json data in CI module.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'click>=7.0,<8.0',
         # TODO: remove these pins on flask/extensions once the celery issue above is resolved
         'flask-restx>=0.4.0',
+        'SQLAlchemy<=1.4',
         'Flask-SQLAlchemy>=2.5.1,<3.0.0',
         'Flask-WTF>=0.14.3,<1.0.0',
         'Flask-DebugToolbar>=0.11.0,<1.0.0',


### PR DESCRIPTION
See [otello issue #14](https://github.com/hysds/otello/issues/14).

Newer versions of Flask, flask-rstx and Werkzeug impose more strict enforcement of specifying Content-type when attempt is made to access the request data as json. This exposes an issue in Otello where json data for job registration and job building post() functions is submitted as 'data', thereby omitting the Content-type header (based on how the python module requests behaves) - creating a 400 on the mozart side.

The fix here intends to be consistent with how other mozart side code handles incoming request data, while at the same time not breaking anyone accessing the Mozart endpoint directly (e.g. via curl). It also does not change Otello itself.

Note that there are several other places in Mozart which access request.json:

- api_v01/tags.py
- api_v01/jobs.py
- api_v01/user_rules.py
- api_v02/tags.py
- api_v02/jobs.py
- api_v02/user_rules.py

However, I could not identify any API (and hence the use of the requests module) which accesses the associated POST endpoints so they were not changed in fear of inadvertently breaking something that is obviously working now.