### PR TITLE
Hot fix: pin to use latest cryptography

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,6 @@ setup(
         'pytz',
         'numpy',
         "werkzeug>=2.2.0",  # TODO: remove this pin after fix has been made https://stackoverflow.com/a/73105878
-        "cryptography"
+        "cryptography>=39.0.0"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,6 @@ setup(
         'pytz',
         'numpy',
         "werkzeug>=2.2.0",  # TODO: remove this pin after fix has been made https://stackoverflow.com/a/73105878
+        "cryptography"
     ]
 )


### PR DESCRIPTION
During testing with trying to deploy a cluster with the Pele hot fix: https://github.com/hysds/pele/pull/30, the following error was seen when trying to install the Mozart code:

![image](https://user-images.githubusercontent.com/42812746/222022970-75736f3e-717e-42c2-9686-da23573be4f6.png)

The hot fix is to ensure that we are using the latest cryptography. It looks like cryptography 3.4.8 is initially installed, but in doing a global search on the hysds repo, I can't seem to find where this is set. So, this seemed to be the best solution.
