### PR TITLE
job_status-* instead of job_status-current

### DIFF
--- a/mozart/lib/job_utils.py
+++ b/mozart/lib/job_utils.py
@@ -17,7 +17,7 @@ def get_job_status(_id):
         raise Exception("'id' must be supplied by request")
 
     es_index = "job_status-current"
-    status = mozart_es.get_by_id(index=es_index, id=_id, _source_includes=['status'], ignore=404)
+    status = mozart_es.search_by_id(index=es_index, id=_id, _source_includes=['status'], ignore=404)
     if status['found'] is False:
         raise Exception("job _id not found")
 
@@ -45,7 +45,7 @@ def get_job_info(_id):
         raise Exception("'id' must be supplied by request")
 
     es_index = "job_status-current"
-    result = mozart_es.get_by_id(index=es_index, id=_id, ignore=404)
+    result = mozart_es.search_by_id(index=es_index, id=_id, ignore=404)
     if result['found'] is False:
         raise Exception('job _id not found: %s' % _id)
 

--- a/mozart/services/api_v01/jobs.py
+++ b/mozart/services/api_v01/jobs.py
@@ -327,7 +327,7 @@ class GetJobStatus(Resource):
         if _id is None:
             return {'success': False, 'message': 'id not supplied'}, 400
 
-        job_status = mozart_es.get_by_id(index=JOB_STATUS_INDEX, id=_id, ignore=404, _source=['status'])
+        job_status = mozart_es.search_by_id(index=JOB_STATUS_INDEX, id=_id, ignore=404, _source=['status'])
         if job_status['found'] is False:
             return {
                 'success': False,
@@ -367,7 +367,7 @@ class GetJobInfo(Resource):
                 'message': 'id must be supplied (as query param or url param)'
             }, 400
 
-        info = mozart_es.get_by_id(index=JOB_STATUS_INDEX, id=_id, ignore=404)
+        info = mozart_es.search_by_id(index=JOB_STATUS_INDEX, id=_id, ignore=404)
         if info['found'] is False:
             return {
                 'success': False,
@@ -387,7 +387,7 @@ class GetJobInfo(Resource):
 class ProductsStaged(Resource):
     def get(self, _id):
         doc_fields = ['status', 'job.job_info.metrics.products_staged']
-        prod = mozart_es.get_by_id(index=JOB_STATUS_INDEX, id=_id, _source_includes=doc_fields, ignore=404)
+        prod = mozart_es.search_by_id(index=JOB_STATUS_INDEX, id=_id, _source_includes=doc_fields, ignore=404)
         app.logger.info('fetch products staged for %s' % _id)
 
         if prod['found'] is False:

--- a/mozart/services/api_v01/tags.py
+++ b/mozart/services/api_v01/tags.py
@@ -38,17 +38,17 @@ class UserTags(Resource):
         tag = request_data.get('tag')
         app.logger.info('_id: %s\n _index: %s\n tag: %s' % (_id, _index, tag))
 
-        if _index != 'job_status-current':
-            app.logger.error('user tags only for index: job_status-current')
-            return {
-                'success': False,
-                'message': 'user tags only for index: job_status-current'
-            }, 400
-
         if _id is None or _index is None or tag is None:
             return {
                 'success': False,
                 'message': 'id, index and tag must be supplied'
+            }, 400
+
+        if not _index.startswith("job_status-"):
+            app.logger.error('user tags only for index: job_status-*')
+            return {
+                'success': False,
+                'message': 'user tags only for index: job_status-*'
             }, 400
 
         dataset = mozart_es.get_by_id(index=_index, id=_id, ignore=404)

--- a/mozart/services/api_v02/jobs.py
+++ b/mozart/services/api_v02/jobs.py
@@ -280,7 +280,7 @@ class JobStatus(Resource):
         if _id is None:
             return {'success': False, 'message': 'id not supplied'}, 400
 
-        job_status = mozart_es.get_by_id(index=JOB_STATUS_INDEX, id=_id, ignore=404, _source=['status'])
+        job_status = mozart_es.search_by_id(index=JOB_STATUS_INDEX, id=_id, ignore=404, _source=['status'])
         if job_status['found'] is False:
             return {
                 'success': False,
@@ -346,7 +346,7 @@ class JobInfo(Resource):
                 }, 400
             _id = request.args.get('id')
 
-        info = mozart_es.get_by_id(index=JOB_STATUS_INDEX, id=_id, ignore=404)
+        info = mozart_es.search_by_id(index=JOB_STATUS_INDEX, id=_id, ignore=404)
         if info['found'] is False:
             return {
                 'success': False,

--- a/mozart/services/api_v02/tags.py
+++ b/mozart/services/api_v02/tags.py
@@ -37,17 +37,17 @@ class UserTags(Resource):
         tag = request_data.get('tag')
         app.logger.info('_id: %s\n _index: %s\n tag: %s' % (_id, _index, tag))
 
-        if _index != 'job_status-current':
-            app.logger.error('user tags only for index: job_status-current')
-            return {
-                'success': False,
-                'message': 'user tags only for index: job_status-current'
-            }, 400
-
         if _id is None or _index is None or tag is None:
             return {
                 'success': False,
                 'message': 'id, index and tag must be supplied'
+            }, 400
+
+        if not _index.startswith("job_status-"):
+            app.logger.error('user tags only for index: job_status-*')
+            return {
+                'success': False,
+                'message': 'user tags only for index: job_status-*'
             }, 400
 
         dataset = mozart_es.get_by_id(index=_index, id=_id, ignore=404)


### PR DESCRIPTION
fixing the bug in `dump_job_status.py` when there are more than 2 `job_status-*` indices
- using `search_by_id` instead of `get_by_id` when searching on `job_status-*` indices

https://nisar-pcm-ci.jpl.nasa.gov/job/force-branches/job/dustinlo-force_branch-E2E-test/25