### PR TITLE
hot-fix: Pin python-jenkins to 1.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mozart',
-    version='2.1.0',
+    version='2.2.0',
     long_description='HySDS job orchestration/worker web interface',
     packages=find_packages(),
     include_package_data=True,
@@ -33,7 +33,7 @@ setup(
         'boto>=2.38.0',
         'python-dateutil',
         'elasticsearch>=7.0.0,<7.14.0',
-        'python-jenkins>=1.7.0',
+        'python-jenkins==1.7.0',
         'future>=0.17.1',
         'pytz',
         'numpy',


### PR DESCRIPTION
We encountered an error during cluster provisioning regarding setuptools:

![image](https://user-images.githubusercontent.com/42812746/228076012-8f264917-8c09-461c-9c5d-02dd8bc1be1a.png)

When tracing down the setuptools dependencies using:

```
pip install pipdeptree
pipdeptree --reverse --packages setuptools
```

it indicated that python-jenkins 1.8.0 needed an older version of setuptools:

![image](https://user-images.githubusercontent.com/42812746/228076209-e41aa522-1ba0-4855-8361-820433c484e9.png)

This hot-fix will pin python-jenkins to 1.7.0
