### PR TITLE
HOTFIX: pin flask b/c 2.3.0 breaks flask debugtoolbar

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mozart',
-    version='2.2.0',
+    version='2.2.1',
     long_description='HySDS job orchestration/worker web interface',
     packages=find_packages(),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'Flask>=2.2.0',
+        'Flask<2.3.0',  # TODO: remove kluge when Flask-DebugToolbar fixes import error
         'flask-restx>=0.5.1',
         'Flask-SQLAlchemy>=3.0.0',
         'Flask-WTF>=0.15.1',


### PR DESCRIPTION
Flask created a new release `2.3.0` on 4/25:
https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-3-0

when running `sds -d update grq` it breaks when running `flask create-db`:
```
flask create-db
Error: While importing 'app', an ImportError was raised:

Traceback (most recent call last):
  File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/flask/cli.py", line 218, in locate_app
    __import__(module_name)
  File "/export/home/hysdsops/sciflo/ops/pele/app.py", line 6, in <module>
    from pele import create_app, db
  File "/export/home/hysdsops/sciflo/ops/pele/pele/__init__.py", line 11, in <module>
    from pele.extensions import (cache, assets_env, debug_toolbar, login_manager, cors, bcrypt, db, limiter, mail)
  File "/export/home/hysdsops/sciflo/ops/pele/pele/extensions.py", line 4, in <module>
    from flask_debugtoolbar import DebugToolbarExtension
  File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/flask_debugtoolbar/__init__.py", line 12, in <module>
    from flask_debugtoolbar.utils import decode_text, gzip_compress, gzip_decompress
  File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/flask_debugtoolbar/utils.py", line 23, in <module>
    from flask import current_app, Markup
ImportError: cannot import name 'Markup' from 'flask' (/export/home/hysdsops/sciflo/lib/python3.9/site-packages/flask/__init__.py)


Usage: flask [OPTIONS] COMMAND [ARGS]...
Try 'flask --help' for help.

Error: No such command 'create-db'.
```

traced it down to `flask_debugtoolbar`, looks incompatible with Flask 2.3.0
https://github.com/pallets-eco/flask-debugtoolbar/blob/master/setup.py#L7