### PR TITLE
HC-469: Python tool to install the base ES template

### DIFF
--- a/scripts/install_base_es_template.py
+++ b/scripts/install_base_es_template.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
+import os
+import sys
+import json
+
+from hysds.es_util import get_mozart_es
+mozart_es = get_mozart_es()
+
+
+def write_template(tmpl_file):
+    """Write template to ES."""
+
+    with open(tmpl_file) as f:
+        tmpl = json.load(f)
+
+    # https://elasticsearch-py.readthedocs.io/en/1.3.0/api.html#elasticsearch.Elasticsearch.put_template
+    mozart_es.es.indices.put_template(name="index_defaults", body=tmpl, ignore=400)
+    print(f"Successfully installed template to index_defaults:\n{json.dumps(tmpl, indent=2)}")
+
+
+if __name__ == "__main__":
+
+    # get template file
+    tmpl_file = os.path.abspath(sys.argv[1])
+
+    write_template(tmpl_file)

--- a/scripts/install_base_es_template.sh
+++ b/scripts/install_base_es_template.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+BASE_PATH=$(dirname "${BASH_SOURCE}")
+BASE_PATH=$(cd "${BASE_PATH}"; pwd)
+export PYTHONPATH=$BASE_PATH/..:$PYTHONPATH
+
+# install ops and dev templates
+$BASE_PATH/install_base_es_template.py $*

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mozart',
-    version='2.2.1',
+    version='2.2.2',
     long_description='HySDS job orchestration/worker web interface',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
- This PR adds a python tool which will install the base ES template rather than hitting the ES REST API point as was being done in SDS CLI.
- This is in conjunction with https://github.com/sdskit/sdscli/pull/102

Verified that the Mozart ES had the template installed properly:

![image](https://github.com/hysds/mozart/assets/42812746/c6da609a-ec37-42da-8f09-594fead76588)


