### PR TITLE
Fix empty logging

### DIFF
--- a/mozart/__init__.py
+++ b/mozart/__init__.py
@@ -6,6 +6,7 @@ from future import standard_library
 standard_library.install_aliases()
 
 import os
+
 from flask import Flask, jsonify
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
@@ -142,3 +143,12 @@ app.register_blueprint(api_v01_services)
 
 from mozart.services.api_v02.service import services as api_v02_services
 app.register_blueprint(api_v02_services)
+
+
+if __name__ != '__main__':
+    import logging
+
+    gunicorn_logger = logging.getLogger('gunicorn.error')
+    app.logger.handlers = gunicorn_logger.handlers
+    app.logger.setLevel(gunicorn_logger.level)
+    app.logger.propagate = False

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mozart',
-    version='2.2.2',
+    version='2.2.3',
     long_description='HySDS job orchestration/worker web interface',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
change(s):
- fixed the logging issue where `app.logger.info` would not show in `mozart_job_management.log`
- bump version

before mozart would only log gunicorn events and error/warning logs (ex. `app.logger.error(...)`)
according to [this article](https://trstringer.com/logging-flask-gunicorn-the-manageable-way/), the best fix is to add this block to the flask app:
```python
if __name__ != '__main__':
    gunicorn_logger = logging.getLogger('gunicorn.error')
    app.logger.handlers = gunicorn_logger.handlers
    app.logger.setLevel(gunicorn_logger.level)
    app.logger.propagate = False
```

before, `INFO` logging would be missing and no formatting for error/warning logs:
```
[2023-05-26 00:32:34 +0000] [26171] [DEBUG] POST /api/v0.2/job/list
sample warning log...
sample error log...
```

after:
```
[2023-05-26 00:51:59 +0000] [26842] [DEBUG] POST /api/v0.2/job/list
[2023-05-26 00:51:59 +0000] [26842] [INFO] sample info log  # <----- this is what we want to see
[2023-05-26 00:51:59 +0000] [26842] [WARNING] sample warning log...
[2023-05-26 00:51:59 +0000] [26842] [ERROR] sample error log...
[2023-05-26 00:51:59 +0000] [26842] [DEBUG] Closing connection. 
```

we need to also add `app.logger.propagate = False` b/c for some reason mozart logs everything twice, can't seem to find why it does that
```
[2023-05-26 00:32:34 +0000] [26171] [DEBUG] POST /api/v0.2/job/list
[2023-05-26 00:32:34 +0000] [26171] [INFO] sample warning log...
sample warning log...
```