### PR TITLE
HC-496: Updates to optionally support a separate Mozart ES cluster deployment

### DIFF
--- a/scripts/install_es_template.py
+++ b/scripts/install_es_template.py
@@ -7,6 +7,7 @@ from builtins import open
 from future import standard_library
 standard_library.install_aliases()
 
+import argparse
 import os
 from jinja2 import Template
 
@@ -14,6 +15,25 @@ from hysds.es_util import get_mozart_es
 
 
 mozart_es = get_mozart_es()
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description="Tool to install Mozart ES templates to the cluster.")
+    parser.add_argument(
+        "--install_job_templates",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Optionally specify this flag to install the job templates (job_status, worker_status, "
+             "event_status, task_status).",
+    )
+    parser.add_argument(
+        "--template_dir",
+        required=False,
+        type=str,
+        help="Optionally specify this flag to tell the tool where to find the given templates.",
+    )
+    return parser
 
 
 def write_template(index, tmpl_file):
@@ -31,11 +51,30 @@ def write_template(index, tmpl_file):
 
 
 if __name__ == "__main__":
-    indices = ("containers", "job_specs", "hysds_ios")
+    args = get_parser().parse_args()
 
-    curr_file = os.path.dirname(__file__)
-    tmpl_file = os.path.abspath(os.path.join(curr_file, '..', 'configs', 'es_template.json'))
-    tmpl_file = os.path.normpath(tmpl_file)
+    if args.install_job_templates is False:
+        indices = ("containers", "job_specs", "hysds_ios")
 
-    for index in indices:
-        write_template(index, tmpl_file)
+        curr_file = os.path.dirname(__file__)
+        tmpl_file = os.path.abspath(os.path.join(curr_file, '..', 'configs', 'es_template.json'))
+        tmpl_file = os.path.normpath(tmpl_file)
+
+        for index in indices:
+            write_template(index, tmpl_file)
+    else:
+        templates = [
+            "job_status.template",
+            "worker_status.template",
+            "task_status.template",
+            "event_status.template"
+        ]
+        if args.template_dir is None:
+            raise RuntimeError(f"Must specify --template_dir when installing job templates.")
+
+        for template in templates:
+            # Copy templates to etc/ directory
+            template_file = f"{args.template_dir}/mozart/etc/{template}"
+            template_doc_name = template.split(".template")[0]
+            print(f"Creating ES index template for {template}")
+            write_template(template_doc_name, template_file)

--- a/scripts/install_es_template.py
+++ b/scripts/install_es_template.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
 
         for template in templates:
             # Copy templates to etc/ directory
-            template_file = f"{args.template_dir}/mozart/etc/{template}"
+            template_file = f"{args.template_dir}/{template}"
             template_doc_name = template.split(".template")[0]
             print(f"Creating ES index template for {template}")
             write_template(template_doc_name, template_file)

--- a/scripts/install_es_template.py
+++ b/scripts/install_es_template.py
@@ -50,6 +50,20 @@ def write_template(index, tmpl_file):
     print("Successfully installed template %s" % index)
 
 
+def write_index_template(index, tmpl_file):
+    """Write template to ES."""
+
+    with open(tmpl_file) as f:
+        tmpl = Template(f.read()).render(index=index)
+
+    # https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.delete_template
+    mozart_es.es.indices.delete_index_template(name=index, ignore=[400, 404])
+
+    # https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.put_template
+    mozart_es.es.indices.put_index_template(name=index, body=tmpl)
+    print("Successfully installed index template %s" % index)
+
+
 if __name__ == "__main__":
     args = get_parser().parse_args()
 
@@ -77,4 +91,4 @@ if __name__ == "__main__":
             template_file = f"{args.template_dir}/{template}"
             template_doc_name = template.split(".template")[0]
             print(f"Creating ES index template for {template}")
-            write_template(template_doc_name, template_file)
+            write_index_template(template_doc_name, template_file)

--- a/scripts/install_ilm_policy.py
+++ b/scripts/install_ilm_policy.py
@@ -25,6 +25,13 @@ def get_parser():
         type=str,
         help="Specify the Mozart ILM policy file.",
     )
+    parser.add_argument(
+        "--ilm_policy_name",
+        required=False,
+        type=str,
+        default="ilm_policy_mozart",
+        help="Optionally specify the Mozart ILM policy name. Defaults to 'ilm_policy_mozart'",
+    )
     return parser
 
 
@@ -37,5 +44,5 @@ if __name__ == "__main__":
     # https://elasticsearch-py.readthedocs.io/en/7.x/api.html#elasticsearch.client.IlmClient
     # ignore 400 cause by IndexAlreadyExistsException when creating an index
     es_ilm = IlmClient(mozart_es.es)
-    es_ilm.put_lifecycle(policy="ilm_policy_mozart", body=ilm_policy)
+    es_ilm.put_lifecycle(policy=args.ilm_policy_name, body=ilm_policy)
     print(f"Successfully installed ILM policy to index-delete-policy:\n{json.dumps(ilm_policy, indent=2)}")

--- a/scripts/install_ilm_policy.py
+++ b/scripts/install_ilm_policy.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
+
+import argparse
+import json
+
+from elasticsearch.client import IlmClient
+from hysds.es_util import get_mozart_es
+
+
+mozart_es = get_mozart_es()
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description="Tool to install Mozart ES ILM Policy")
+    parser.add_argument(
+        "--policy_file",
+        required=True,
+        type=str,
+        help="Specify the Mozart ILM policy file.",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    args = get_parser().parse_args()
+
+    with open(args.policy_file) as f:
+        ilm_policy = json.load(f)
+
+    # https://elasticsearch-py.readthedocs.io/en/7.x/api.html#elasticsearch.client.IlmClient
+    # ignore 400 cause by IndexAlreadyExistsException when creating an index
+    es_ilm = IlmClient(mozart_es.es)
+    es_ilm.put_lifecycle(policy="ilm_policy_mozart", body=ilm_policy)
+    print(f"Successfully installed ILM policy to index-delete-policy:\n{json.dumps(ilm_policy, indent=2)}")

--- a/scripts/install_ilm_policy.py
+++ b/scripts/install_ilm_policy.py
@@ -45,4 +45,4 @@ if __name__ == "__main__":
     # ignore 400 cause by IndexAlreadyExistsException when creating an index
     es_ilm = IlmClient(mozart_es.es)
     es_ilm.put_lifecycle(policy=args.ilm_policy_name, body=ilm_policy)
-    print(f"Successfully installed ILM policy to index-delete-policy:\n{json.dumps(ilm_policy, indent=2)}")
+    print(f"Successfully installed ILM policy to {args.ilm_policy_name}:\n{json.dumps(ilm_policy, indent=2)}")

--- a/scripts/install_ilm_policy.sh
+++ b/scripts/install_ilm_policy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+BASE_PATH=$(dirname "${BASH_SOURCE}")
+BASE_PATH=$(cd "${BASE_PATH}"; pwd)
+export PYTHONPATH=$BASE_PATH/..:$PYTHONPATH
+
+# install templates for containers, job_specs, and hysds_ios
+$BASE_PATH/install_ilm_policy.py $*

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mozart',
-    version='2.2.4',
+    version='2.2.5',
     long_description='HySDS job orchestration/worker web interface',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
- Updated the existing `install_es_template.sh` script to additionally support the installation of the job-related templates. See the associated sdscli repo for details on how this script is called now to install the job-related templates: https://github.com/sdskit/sdscli/pull/103. We pass in the `--install_job_templates --template_dir {target_dir}` flag options to tell the tool to install these templates.
- Created a new script to install the Mozart ILM policy. This script is called within sdscli. See https://github.com/sdskit/sdscli/pull/103


Running a force branch on swot: https://swot-pcm-ci.jpl.nasa.gov/job/force-branches/job/andrewmz-force_branch-E2E-test/192/