### PR TITLE
HC-606: Updated to support migration to OpenSearch 3.x

### DIFF
--- a/scripts/create_hysds_ios_index.py
+++ b/scripts/create_hysds_ios_index.py
@@ -27,4 +27,4 @@ with open(path) as f:
     body = {**body, **user_rules_mapping}
 
 # create destination index
-mozart_es.es.indices.create(HYSDS_IOS_INDEX, body, ignore=400)
+mozart_es.es.indices.create(index=HYSDS_IOS_INDEX, body=body, ignore=400)

--- a/scripts/create_user_rules_index.py
+++ b/scripts/create_user_rules_index.py
@@ -27,4 +27,4 @@ with open(path) as f:
     body = {**body, **user_rules_mapping}
 
 # create destination index
-mozart_es.es.indices.create(USER_RULES_INDEX, body, ignore=400)
+mozart_es.es.indices.create(index=USER_RULES_INDEX, body=body, ignore=400)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="mozart",
-    version="3.1.0",
+    version="3.2.0",
     long_description="HySDS job orchestration/worker web interface",
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
This updates the create_user_rules and create_hysds_ios_index scripts to conform to the OpenSearch 3.X API requirements: using keyword args and doing away with positional args